### PR TITLE
Add hook for handling infinfinite scroll & pagination functionality

### DIFF
--- a/src/hooks/useFetchList.ts
+++ b/src/hooks/useFetchList.ts
@@ -18,25 +18,46 @@ interface BookData {
   docs: Book[];
 }
 
+interface Params {
+  q: string;
+  page: number;
+  limit: number;
+}
+
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-const getPaginatedData = async (url: string) => {
-  const { data } = await openLibAxiosInstance.get<BookData>(url);
+const getPaginatedData = async ([url, params]: [string, Params]) => {
+  const { data } = await openLibAxiosInstance.get<BookData>(url, { params });
 
   return data;
 };
 
 const getKey = (pageIndex: number) => {
-  return `search.json?q=the+lord+of+the+rings&page=${pageIndex + 1}&limit=50`;
+  const params: Params = {
+    q: "the lord of the rings",
+    page: pageIndex + 1,
+    limit: 50,
+  };
+  return [`search.json`, params];
 };
 
-export const useFetchPaginatedList = () => {
-  const result = useSWRInfinite(getKey, getPaginatedData, {
-    onSuccess(data, key, config) {
-      console.log(data);
+export const useFetchPaginatedList = (pageSize: number, query: string) => {
+  const result = useSWRInfinite(
+    (pageIndex: number) => {
+      return [
+        `search.json`,
+        { q: query, page: pageIndex + 1, limit: pageSize },
+      ];
     },
-    revalidateFirstPage: false,
-  });
+    getPaginatedData,
+    {
+      onSuccess(data, key, config) {
+        console.log(data);
+        console.log(key);
+      },
+      revalidateFirstPage: false,
+    }
+  );
 
   return {
     ...result,

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,37 @@
+import { MutableRefObject, useCallback, useRef } from "react";
+
+export const useInfiniteScroll = (
+  fetchNextPage: () => void,
+  skipSettingRef: boolean,
+  isValidating: boolean,
+  isLoading: boolean
+) => {
+  // Setting up the observer
+  const observer = useRef() as MutableRefObject<IntersectionObserver>;
+
+  const targetResultRef = useCallback(
+    (node: HTMLLIElement) => {
+      if (skipSettingRef) {
+        return;
+      }
+      // Disconnect current observer, as we want to set-up a new one
+      if (observer.current) {
+        observer.current.disconnect();
+      }
+
+      observer.current = new IntersectionObserver((entries) => {
+        // Increase page number if the last result is visible & more data is available
+        if (entries[0].isIntersecting && typeof fetchNextPage === "function") {
+          fetchNextPage();
+        }
+      });
+
+      if (node) {
+        observer.current?.observe(node);
+      }
+    },
+    [isLoading, isValidating]
+  );
+
+  return { offsetTargetElementRef: targetResultRef };
+};


### PR DESCRIPTION
Added a `useInfiniteScroll` hook that:
- Takes the following arguments:
  - A function for fetching next page data
  - boolean for skipping ref setup
  - booleans for when data is loading and updating (validating)
- Returns a `ref` to the element in the list which will be the target element for triggering data fetching for subsequent pages. (when visible on the screen, it triggers the function for fetching next page data) 

When used in conjunction with the `useFetchPaginatedList` hook, it can be used to paginate the list.